### PR TITLE
Fixed variable name for client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ If you want to use quickstart, then send only the first two properties.
 
 ``` {.sourceCode .javascript}
 var Client = require("ibmiotf");
-var config = {
+var appClientConfig = {
     "org" : orgId,
     "id" : appId,
     "auth-key" : apiKey,


### PR DESCRIPTION
I believe variable the name should be appClientConfig ... as that is the one that get's passed into the various IotfApplication functions.